### PR TITLE
Improve Pokemon detail data and list images

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/data/Models.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/data/Models.kt
@@ -18,10 +18,36 @@ data class PokemonResult(
 data class PokemonDetail(
     val id: Int,
     val name: String,
-    val sprites: Sprites
+    val sprites: Sprites,
+    val weight: Int? = null,
+    val height: Int? = null,
+    @SerialName("base_experience") val baseExperience: Int? = null,
+    val types: List<TypeSlot> = emptyList()
 )
 
 @Serializable
 data class Sprites(
+    @SerialName("front_default") val frontDefault: String? = null,
+    val other: OtherSprites? = null
+)
+
+@Serializable
+data class OtherSprites(
+    @SerialName("official-artwork") val officialArtwork: OfficialArtwork? = null
+)
+
+@Serializable
+data class OfficialArtwork(
     @SerialName("front_default") val frontDefault: String? = null
+)
+
+@Serializable
+data class TypeSlot(
+    val slot: Int,
+    val type: Type
+)
+
+@Serializable
+data class Type(
+    val name: String
 )

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -29,8 +29,10 @@ fun PokemonDetailScreen(name: String, repository: PokemonRepository) {
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        val imageUrl = detail.sprites.other?.officialArtwork?.frontDefault
+            ?: detail.sprites.frontDefault
         AsyncImage(
-            model = detail.sprites.frontDefault,
+            model = imageUrl,
             contentDescription = null,
             modifier = Modifier.size(200.dp)
         )
@@ -48,5 +50,22 @@ fun PokemonDetailScreen(name: String, repository: PokemonRepository) {
         }
         Spacer(Modifier.height(8.dp))
         Text(text = "ID: ${detail.id}", style = MaterialTheme.typography.bodyLarge)
+        detail.height?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(text = "Height: $it", style = MaterialTheme.typography.bodyLarge)
+        }
+        detail.weight?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(text = "Weight: $it", style = MaterialTheme.typography.bodyLarge)
+        }
+        detail.baseExperience?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(text = "Base Exp: $it", style = MaterialTheme.typography.bodyLarge)
+        }
+        if (detail.types.isNotEmpty()) {
+            Spacer(Modifier.height(4.dp))
+            val types = detail.types.joinToString { it.type.name }
+            Text(text = "Types: $types", style = MaterialTheme.typography.bodyLarge)
+        }
     }
 }

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
@@ -72,9 +72,9 @@ private fun PokemonRow(
     ) {
         val id = pokemon.url.trimEnd('/').split("/").last()
         AsyncImage(
-            model = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/$id.png",
+            model = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/$id.png",
             contentDescription = null,
-            modifier = Modifier.size(56.dp),
+            modifier = Modifier.size(72.dp),
             contentScale = ContentScale.Crop,
             placeholder = painterResource(R.drawable.ic_launcher_foreground)
         )


### PR DESCRIPTION
## Summary
- enrich Pokemon detail model with weight, height, base experience and types
- display extra info on the detail screen
- fetch higher quality artwork in the list and enlarge images

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fe7b9ba90832bb07fd84e9e672c16