### PR TITLE
Improve detail loading UX

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -37,7 +38,16 @@ fun PokemonDetailScreen(
     viewModel: PokemonDetailViewModel = koinViewModel()
 ) {
     val detailState by viewModel.detail.collectAsState()
-    val detail: PokemonDetail = detailState ?: return
+    if (detailState == null) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+    val detail: PokemonDetail = detailState!!
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(


### PR DESCRIPTION
## Summary
- show CircularProgressIndicator while Pokemon details are being fetched

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ff076b7b0832b86c0c5aecf360e32