### PR TITLE
Add dependency for extended material icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material3)
     implementation(libs.ktor.client.android)
     implementation(libs.ktor.client.content.negotiation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Material icons extended dependency in version catalog
- include icons dependency in app module build script

## Testing
- `./gradlew tasks --all` *(fails: unable to tunnel through proxy)*
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ff66d838c832b8c9fb4c6f2f8431d