### PR TITLE
Implement unsorted default list

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
@@ -65,7 +65,7 @@ fun PokemonListScreen(
     viewModel: PokemonListViewModel = koinViewModel()
 ) {
     var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
-    var sortOption by remember { mutableStateOf(SortOption.A_Z) }
+    var sortOption by remember { mutableStateOf<SortOption?>(null) }
     val pokemonList by viewModel.pokemonList.collectAsState()
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         OutlinedTextField(
@@ -99,6 +99,7 @@ fun PokemonListScreen(
             SortOption.POWER -> filtered.sortedByDescending {
                 it.url.trimEnd('/').split("/").last().toIntOrNull() ?: 0
             }
+            null -> filtered
         }
         if (sorted.isEmpty()) {
             Column(


### PR DESCRIPTION
## Summary
- make sorting option nullable so the first screen isn't sorted

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7ddf22c832b967dcfbfa82bf1f5