### PR TITLE
Add color mapping for Pokemon types

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -41,7 +41,7 @@ import coil.compose.AsyncImage
 import com.halil.ozel.pokemonapp.data.PokemonDetail
 import com.halil.ozel.pokemonapp.R
 import org.koin.androidx.compose.koinViewModel
-import kotlin.random.Random
+import com.halil.ozel.pokemonapp.ui.theme.getColorFromType
 
 @Composable
 fun PokemonDetailScreen(
@@ -123,7 +123,7 @@ fun PokemonDetailScreen(
                     Spacer(Modifier.height(8.dp))
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         detail.types.forEach { typeSlot ->
-                            val color = Color(Random.nextInt(0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
+                            val color = getColorFromType(typeSlot.type.name)
                             Card(
                                 shape = RoundedCornerShape(50),
                                 colors = CardDefaults.cardColors(containerColor = color)

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/theme/TypeColor.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/theme/TypeColor.kt
@@ -1,0 +1,27 @@
+package com.halil.ozel.pokemonapp.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+fun getColorFromType(type: String): Color {
+    return when (type.lowercase()) {
+        "bug" -> Color(0xFF8BD674)
+        "dark" -> Color(0xFF6F6E78)
+        "dragon" -> Color(0xFF7383B9)
+        "electric" -> Color(0xFFFFD86F)
+        "fairy" -> Color(0xFFEBA8C3)
+        "fighting" -> Color(0xFFEB4971)
+        "fire" -> Color(0xFFFB6C6C)
+        "flying" -> Color(0xFF83A2E3)
+        "ghost" -> Color(0xFF8571BE)
+        "grass" -> Color(0xFF48D0B0)
+        "ground" -> Color(0xFFF78551)
+        "ice" -> Color(0xFF91D8DF)
+        "normal" -> Color(0xFFB5B9C4)
+        "poison" -> Color(0xFF9F6E97)
+        "psychic" -> Color(0xFFFF6568)
+        "rock" -> Color(0xFFD4C294)
+        "steel" -> Color(0xFF4C91B2)
+        "water" -> Color(0xFF76BDFE)
+        else -> Color.Black
+    }
+}


### PR DESCRIPTION
## Summary
- add a utility that maps Pokemon type names to colors
- use this utility in `PokemonDetailScreen` to color the type chips

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ffdb1d544832bb4ef9f59b6c50d63