### PR TITLE
Add type-based colors to Pokemon cards

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonListScreen.kt
@@ -49,6 +49,7 @@ import coil.compose.AsyncImage
 import com.halil.ozel.pokemonapp.R
 import com.halil.ozel.pokemonapp.data.ApiConstants
 import com.halil.ozel.pokemonapp.data.PokemonResult
+import com.halil.ozel.pokemonapp.ui.theme.getColorFromType
 import org.koin.androidx.compose.koinViewModel
 
 private enum class SortOption(val icon: ImageVector, val label: String) {
@@ -148,10 +149,14 @@ private fun PokemonGridItem(
     viewModel: PokemonListViewModel,
     onClick: () -> Unit
 ) {
+    val types by viewModel.pokemonTypes.collectAsState()
+    val typeColor = types[pokemon.name]?.let { getColorFromType(it) }
+
     Card(
         modifier = Modifier
             .padding(8.dp)
             .clickable { onClick() },
+        colors = if (typeColor != null) CardDefaults.cardColors(containerColor = typeColor) else CardDefaults.cardColors(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(8.dp)) {


### PR DESCRIPTION
## Summary
- fetch Pokemon types when loading the list
- expose pokemon type map from list view model
- color list screen cards based on each Pokemon's primary type

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ffec489d4832b8136cd373853a6fe