### PR TITLE
Add color background behind Pokémon photo

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -61,12 +61,15 @@ fun PokemonDetailScreen(
     }
     val detail: PokemonDetail = detailState!!
 
+    val typeColor = detail.types.firstOrNull()?.let { getColorFromType(it.type.name) }
+        ?: MaterialTheme.colorScheme.primary
+
     Column(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
+                .background(typeColor.copy(alpha = 0.2f))
         ) {
             IconButton(
                 onClick = onBack,


### PR DESCRIPTION
## Summary
- colorize header background on the detail screen using Pokémon type

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686001f50180832bb239293871efb513