### PR TITLE
Display evolution chain in detail screen

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/data/ApiConstants.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/data/ApiConstants.kt
@@ -3,6 +3,8 @@ package com.halil.ozel.pokemonapp.data
 object ApiConstants {
     const val BASE_URL = "https://pokeapi.co/api/v2"
     const val POKEMON_ENDPOINT = "${BASE_URL}/pokemon"
+    const val SPECIES_ENDPOINT = "${BASE_URL}/pokemon-species"
+    const val EVOLUTION_CHAIN_ENDPOINT = "${BASE_URL}/evolution-chain"
     const val SPRITE_BASE_URL = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork"
     const val DEFAULT_LIMIT = 151
 }

--- a/app/src/main/java/com/halil/ozel/pokemonapp/data/Models.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/data/Models.kt
@@ -71,3 +71,40 @@ data class StatSlot(
 data class StatDetail(
     val name: String
 )
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class PokemonSpecies(
+    @SerialName("evolution_chain") val evolutionChain: EvolutionChainLink
+)
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class EvolutionChainLink(
+    val url: String
+)
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class EvolutionChain(
+    val chain: ChainLink
+)
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class ChainLink(
+    val species: NamedApiResource,
+    @SerialName("evolves_to") val evolvesTo: List<ChainLink> = emptyList()
+)
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class NamedApiResource(
+    val name: String,
+    val url: String
+)
+
+data class EvolutionPokemon(
+    val name: String,
+    val id: Int
+)

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -39,9 +39,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.halil.ozel.pokemonapp.data.PokemonDetail
+import com.halil.ozel.pokemonapp.data.EvolutionPokemon
 import com.halil.ozel.pokemonapp.R
 import org.koin.androidx.compose.koinViewModel
 import com.halil.ozel.pokemonapp.ui.theme.getColorFromType
+import com.halil.ozel.pokemonapp.data.ApiConstants
 
 @Composable
 fun PokemonDetailScreen(
@@ -50,6 +52,7 @@ fun PokemonDetailScreen(
     viewModel: PokemonDetailViewModel = koinViewModel()
 ) {
     val detailState by viewModel.detail.collectAsState()
+    val evolutions by viewModel.evolutions.collectAsState()
     if (detailState == null) {
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -69,7 +72,7 @@ fun PokemonDetailScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .background(typeColor.copy(alpha = 0.2f))
+                .background(typeColor)
         ) {
             IconButton(
                 onClick = onBack,
@@ -174,6 +177,24 @@ fun PokemonDetailScreen(
                             color = MaterialTheme.colorScheme.primary
                         )
                         Spacer(Modifier.height(8.dp))
+                    }
+                }
+
+                if (evolutions.isNotEmpty()) {
+                    Spacer(Modifier.height(16.dp))
+                    Text(text = stringResource(R.string.evolutions), style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        evolutions.forEach { evo ->
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                AsyncImage(
+                                    model = "${ApiConstants.SPRITE_BASE_URL}/${evo.id}.png",
+                                    contentDescription = null,
+                                    modifier = Modifier.size(80.dp)
+                                )
+                                Text(evo.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() })
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.halil.ozel.pokemonapp.data.PokemonDetail
 import com.halil.ozel.pokemonapp.data.PokemonRepository
+import com.halil.ozel.pokemonapp.data.EvolutionPokemon
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,9 +21,13 @@ class PokemonDetailViewModel(
     private val _detail = MutableStateFlow<PokemonDetail?>(null)
     val detail: StateFlow<PokemonDetail?> = _detail.asStateFlow()
 
+    private val _evolutions = MutableStateFlow<List<EvolutionPokemon>>(emptyList())
+    val evolutions: StateFlow<List<EvolutionPokemon>> = _evolutions.asStateFlow()
+
     init {
         viewModelScope.launch {
             _detail.value = repository.fetchPokemonDetail(name)
+            _evolutions.value = repository.fetchEvolutionNames(name)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="content_not_found">No results 🙁</string>
     <string name="added_to_favorites">Added to favorites ⭐</string>
     <string name="removed_from_favorites">Removed from favorites ❌</string>
+    <string name="evolutions">Evolutions 🔄</string>
 </resources>


### PR DESCRIPTION
## Summary
- support fetching evolution chain from PokeAPI
- add evolution models and repository methods
- expose evolution list from view model
- show evolutions and remove alpha background in detail screen
- add string for evolutions

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686003115170832bb450ed3a16e1cc46