### PR TITLE
Enable navigation from evolutions

### DIFF
--- a/app/src/main/java/com/halil/ozel/pokemonapp/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/MainActivity.kt
@@ -44,7 +44,11 @@ fun PokemonApp() {
             arguments = listOf(navArgument("name") { type = NavType.StringType })
         ) { backStackEntry ->
             val name = backStackEntry.arguments?.getString("name") ?: return@composable
-            PokemonDetailScreen(name = name, onBack = { navController.popBackStack() })
+            PokemonDetailScreen(
+                name = name,
+                onBack = { navController.popBackStack() },
+                onEvolutionClick = { navController.navigate("detail/$it") }
+            )
         }
     }
 }

--- a/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/halil/ozel/pokemonapp/ui/screens/PokemonDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -49,6 +50,7 @@ import com.halil.ozel.pokemonapp.data.ApiConstants
 fun PokemonDetailScreen(
     name: String,
     onBack: () -> Unit = {},
+    onEvolutionClick: (String) -> Unit = {},
     viewModel: PokemonDetailViewModel = koinViewModel()
 ) {
     val detailState by viewModel.detail.collectAsState()
@@ -186,7 +188,10 @@ fun PokemonDetailScreen(
                     Spacer(Modifier.height(8.dp))
                     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                         evolutions.forEach { evo ->
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.clickable { onEvolutionClick(evo.name) }
+                            ) {
                                 AsyncImage(
                                     model = "${ApiConstants.SPRITE_BASE_URL}/${evo.id}.png",
                                     contentDescription = null,


### PR DESCRIPTION
## Summary
- add click support for evolution items
- hook up navigation so tapping an evolution opens its detail page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6860048b5d98832b81ebcc3ff7b41044